### PR TITLE
Add parse_mode to support Markdown in sendMessage

### DIFF
--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -177,6 +177,7 @@ var TelegramApi = function (params)
         if (params.disable_web_page_preview !== undefined) args.disable_web_page_preview = params.disable_web_page_preview;
         if (params.reply_to_message_id !== undefined) args.reply_to_message_id = params.reply_to_message_id;
         if (params.reply_markup !== undefined) args.reply_markup = params.reply_markup;
+        if (params.parse_mode !== undefined) args.parse_mode = params.parse_mode;
 
         _rest({
             method: 'POST',


### PR DESCRIPTION
Added a parse_mode to the sendMessage call to support Markdown messages, as per the Telegram API