### PR TITLE
internalGetUpdates: schedule follow up after error

### DIFF
--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -136,6 +136,9 @@ var TelegramApi = function (params)
         .catch(function(err)
         {
             console.error('[TelegramBot]: Failed to get updates from Telegram servers');
+            
+            // Schedule follow up after error
+            setTimeout(internalGetUpdates, _settings.updates.get_interval);
         });
     }
 


### PR DESCRIPTION
Continue working after `internalGetUpdates` issues
Is also prevent bot closed after inlineQuery #25 