### PR TITLE
setWebhook empty certificate error fix

### DIFF
--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -1046,6 +1046,18 @@ var TelegramApi = function (params)
             var args = {};
 
             if (params.url !== undefined) args.url = params.url;
+            if (!params.certificate)
+            {
+                return _rest({
+                    method: 'POST',
+                    json: true,
+                    formData: args,
+                    uri: _baseurl + 'setWebhook'
+                })
+                .then(commonResponseHandler)
+                .then(resolve)
+                .catch(reject);
+            }
 
             // Check existance of certificate
             fs.exists(params.certificate, function (exists)


### PR DESCRIPTION
Removes `TypeError: path must be a string` error.
Appears when you tryin to setwebhook without path to certificate public key