### PR TITLE
Added error handling inside promise

### DIFF
--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -4,7 +4,11 @@ var fs = require('fs');
 var extend = require('extend');
 var request = require('request-promise');
 var EventEmitter = require('events').EventEmitter;
-var Promise = require('promise');
+var Promise = require('bluebird');
+
+Promise.onPossiblyUnhandledRejection(function(error) {
+  throw error;
+})
 
 /**
  * API params
@@ -17,9 +21,9 @@ var Promise = require('promise');
  *          https                   true/false
  *      updates
  *          enabled                 True if you want to receive updates from telegram (default false)
- *          get_interval            We will fetch updates from Telegram 
+ *          get_interval            We will fetch updates from Telegram
  *                                  each number of milliseconds (default 1000)
- *          pooling_timeout         We will wait for updates during this num of 
+ *          pooling_timeout         We will wait for updates during this num of
  *                                  milliseconds at each attempt before quit (default 0)
  */
 
@@ -49,7 +53,7 @@ var TelegramApi = function (params)
 
     // Create some global vars
     var self = this;
-    var _updatesOffset = 0;    
+    var _updatesOffset = 0;
 
     var _rest = request.defaults({
         proxy: proxy
@@ -60,7 +64,7 @@ var TelegramApi = function (params)
         updates: {
             enabled: false,
             get_interval: 1000,
-            pooling_timeout: 0            
+            pooling_timeout: 0
         }
     };
 
@@ -124,7 +128,7 @@ var TelegramApi = function (params)
                     // Account update_id as next offset
                     // to avoid dublicated updates
                     _updatesOffset = (item.update_id >= _updatesOffset ? item.update_id + 1 : _updatesOffset);
-                    
+
                     // Update events
                     self.emit('update', item);
 
@@ -140,7 +144,7 @@ var TelegramApi = function (params)
                         self.emit('inline.query', item.inline_query);
                         return;
                     }
-                    
+
                     // On inline result is chosen
                     if(item.chosen_inline_result)
                     {
@@ -200,10 +204,10 @@ var TelegramApi = function (params)
      *      text                        Text of the message to be sent
      *      disable_web_page_preview    Disables link previews for links in this message
      *      reply_to_message_id         If the message is a reply, ID of the original message
-     *      reply_markup                Additional interface options. A JSON-serialized object 
-     *                                  for a custom reply keyboard, instructions to hide keyboard 
+     *      reply_markup                Additional interface options. A JSON-serialized object
+     *                                  for a custom reply keyboard, instructions to hide keyboard
      *                                  or to force a reply from the user.
-     *      parse_mode                  Send Markdown, if you want Telegram apps to show bold, italic and 
+     *      parse_mode                  Send Markdown, if you want Telegram apps to show bold, italic and
      *                                  inline URLs in your bot's message
      */
     this.sendMessage = function (params, cb)
@@ -282,12 +286,12 @@ var TelegramApi = function (params)
      * METHOD: sendPhoto
      * PARAMS:
      *      chat_id                 Unique identifier for the message recepient — User or GroupChat id
-     *      photo                   Photo to send. You can either pass a file_id as String to resend 
-     *                              a photo that is already on the Telegram servers, or upload 
+     *      photo                   Photo to send. You can either pass a file_id as String to resend
+     *                              a photo that is already on the Telegram servers, or upload
      *                              a new photo using multipart/form-data.
      *      caption                 Photo caption (may also be used when resending photos by file_id)
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      */
     this.sendPhoto = function (params, cb)
@@ -355,11 +359,11 @@ var TelegramApi = function (params)
      * METHOD: sendAudio
      * PARAMS:
      *      chat_id                 Unique identifier for the message recepient — User or GroupChat id
-     *      audio                   Audio file to send. You can either pass a file_id as String to resend 
-     *                              a audio  that is already on the Telegram servers, or upload 
+     *      audio                   Audio file to send. You can either pass a file_id as String to resend
+     *                              a audio  that is already on the Telegram servers, or upload
      *                              a new audio  using multipart/form-data.
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      *      duration                Duration of the audio in seconds (optional)
      *      performer               Performer (optional)
@@ -440,11 +444,11 @@ var TelegramApi = function (params)
      * METHOD: sendVoice
      * PARAMS:
      *      chat_id                 Unique identifier for the message recepient — User or GroupChat id
-     *      voice                   Audio file to send. You can either pass a file_id as String to resend 
-     *                              a audio  that is already on the Telegram servers, or upload 
+     *      voice                   Audio file to send. You can either pass a file_id as String to resend
+     *                              a audio  that is already on the Telegram servers, or upload
      *                              a new audio  using multipart/form-data.
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      *      duration                Duration of the audio in seconds (optional)
      */
@@ -513,11 +517,11 @@ var TelegramApi = function (params)
      * METHOD: sendDocument
      * PARAMS:
      *      chat_id                 Unique identifier for the message recepient — User or GroupChat id
-     *      document                File to send. You can either pass a file_id as String to resend 
-     *                              a file that is already on the Telegram servers, or upload 
+     *      document                File to send. You can either pass a file_id as String to resend
+     *                              a file that is already on the Telegram servers, or upload
      *                              a new file using multipart/form-data.
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      */
     this.sendDocument = function (params, cb)
@@ -580,11 +584,11 @@ var TelegramApi = function (params)
      * METHOD: sendSticker
      * PARAMS:
      *      chat_id                 Unique identifier for the message recepient — User or GroupChat id
-     *      sticker                 Sticker to send. You can either pass a file_id as String to resend 
-     *                              a sticker that is already on the Telegram servers, or upload 
+     *      sticker                 Sticker to send. You can either pass a file_id as String to resend
+     *                              a sticker that is already on the Telegram servers, or upload
      *                              a new sticker using multipart/form-data.
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      */
     this.sendSticker = function (params, cb)
@@ -647,11 +651,11 @@ var TelegramApi = function (params)
      * METHOD: sendVideo
      * PARAMS:
      *      chat_id                 Unique identifier for the message recepient — User or GroupChat id
-     *      video                   Video to send. You can either pass a file_id as String to resend 
-     *                              a video that is already on the Telegram servers, or upload 
+     *      video                   Video to send. You can either pass a file_id as String to resend
+     *                              a video that is already on the Telegram servers, or upload
      *                              a new video using multipart/form-data.
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      *      duration                Duration in seconds (optional)
      *      caption                 Video caption (may also be used when resending videos by file_id), 0-200 characters
@@ -729,7 +733,7 @@ var TelegramApi = function (params)
      *      latitude                Latitude of location
      *      longitude               Longitude of location
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      */
     this.sendLocation = function (params, cb)
@@ -782,10 +786,10 @@ var TelegramApi = function (params)
      *      title                   Name of the venue
      *      address                 Address of the venue
      *      foursquare_id           Foursquare identifier of the venue
-     *      disable_notification    Sends the message silently. iOS users will not receive a notification, 
+     *      disable_notification    Sends the message silently. iOS users will not receive a notification,
      *                              Android users will receive a notification with no sound.
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      */
     this.sendVenue = function (params, cb)
@@ -820,10 +824,10 @@ var TelegramApi = function (params)
      *      phone_number            Contact's phone number
      *      first_name              Contact's first name
      *      last_name               Contact's last name
-     *      disable_notification    Sends the message silently. iOS users will not receive a notification, 
+     *      disable_notification    Sends the message silently. iOS users will not receive a notification,
      *                              Android users will receive a notification with no sound.
      *      reply_to_message_id     If the message is a reply, ID of the original message
-     *      reply_markup            Additional interface options. A JSON-serialized object for a custom 
+     *      reply_markup            Additional interface options. A JSON-serialized object for a custom
      *                              reply keyboard, instructions to hide keyboard or to force a reply from the user.
      */
     this.sendContact = function (params, cb)
@@ -854,7 +858,7 @@ var TelegramApi = function (params)
     /**
      * METHOD: kickChatMember
      * PARAMS:
-     *      chat_id                 Unique identifier for the target group or 
+     *      chat_id                 Unique identifier for the target group or
      *                              username of the target supergroup (in the format @supergroupusername)
      *      user_id                 Unique identifier of the target user
      */
@@ -886,7 +890,7 @@ var TelegramApi = function (params)
     /**
      * METHOD: unbanChatMember
      * PARAMS:
-     *      chat_id                 Unique identifier for the target group or 
+     *      chat_id                 Unique identifier for the target group or
      *                              username of the target supergroup (in the format @supergroupusername)
      *      user_id                 Unique identifier of the target user
      */
@@ -919,9 +923,9 @@ var TelegramApi = function (params)
      * METHOD: sendChatAction
      * PARAMS:
      *      chat_id                 Unique identifier for the message recepient — User or GroupChat id
-     *      action                  Type of action to broadcast. Choose one, depending on what the user 
-     *                              is about to receive: typing for text messages, upload_photo for photos, 
-     *                              record_video or upload_video for videos, record_audio or upload_audio 
+     *      action                  Type of action to broadcast. Choose one, depending on what the user
+     *                              is about to receive: typing for text messages, upload_photo for photos,
+     *                              record_video or upload_video for videos, record_audio or upload_audio
      *                              for audio files, upload_document for general files, find_location for location data
      */
     this.sendChatAction = function (params, cb)
@@ -995,9 +999,9 @@ var TelegramApi = function (params)
     /**
      * METHOD: getUpdates
      * PARAMS:
-     *      offset                  Identifier of the first update to be returned. Must be greater by one than the highest 
-     *                              among the identifiers of previously received updates. By default, updates starting with 
-     *                              the earliest unconfirmed update are returned. An update is considered confirmed as soon as 
+     *      offset                  Identifier of the first update to be returned. Must be greater by one than the highest
+     *                              among the identifiers of previously received updates. By default, updates starting with
+     *                              the earliest unconfirmed update are returned. An update is considered confirmed as soon as
      *                              getUpdates is called with an offset higher than its update_id.
      *      limit                   Limits the number of updates to be retrieved. Values between 1—100 are accepted. Defaults to 100
      *      timeout                 Timeout in seconds for long polling. Defaults to 0, i.e. usual short polling
@@ -1117,13 +1121,13 @@ var TelegramApi = function (params)
      * PARAMS:
      *      inline_query_id         Unique identifier for the answered query
      *      results                 Array of results for the inline query (API will serialize it by itself)
-     *      cache_time              The maximum amount of time in seconds that the result of the inline 
+     *      cache_time              The maximum amount of time in seconds that the result of the inline
      *                              query may be cached on the server. Defaults to 300.
-     *      is_personal             Pass True, if results may be cached on the server side only for the user 
-     *                              that sent the query. By default, results may be returned to any user 
+     *      is_personal             Pass True, if results may be cached on the server side only for the user
+     *                              that sent the query. By default, results may be returned to any user
      *                              who sends the same query
-     *      next_offset             Pass the offset that a client should send in the next query with 
-     *                              the same text to receive more results. Pass an empty string if there are 
+     *      next_offset             Pass the offset that a client should send in the next query with
+     *                              the same text to receive more results. Pass an empty string if there are
      *                              no more results or if you don‘t support pagination. Offset length can’t exceed 64 bytes.
      */
     this.answerInlineQuery = function (params, cb)

--- a/package.json
+++ b/package.json
@@ -1,35 +1,40 @@
 {
-    "name": "telegram-bot-api",
-    "description": "Node.js module for Telegram Bot API (https://core.telegram.org/bots/api)",
-    "version": "1.1.0",
-    "repository": {
-        "type":"git",
-        "url": "https://github.com/mast/telegram-bot-api.git"
+  "name": "telegram-bot-api",
+  "description": "Node.js module for Telegram Bot API (https://core.telegram.org/bots/api)",
+  "version": "1.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mast/telegram-bot-api.git"
+  },
+  "main": "./lib/telegram-bot.js",
+  "keywords": [
+    "telegram",
+    "nodejs",
+    "node.js",
+    "telegram bot",
+    "bot",
+    "api"
+  ],
+  "author": "Max Stepanov <mast@imast.ru>",
+  "contributors": [
+    {
+      "name": "Max Stepanov",
+      "email": "mast@imast.ru"
     },
-    "main": "./lib/telegram-bot.js",
-    "keywords": [
-        "telegram",
-        "nodejs",
-        "node.js",
-        "telegram bot",
-        "bot",
-        "api"
-    ],
-    "author": "Max Stepanov <mast@imast.ru>",
-    "contributors": [{
-        "name": "Max Stepanov",
-        "email": "mast@imast.ru"
-    }, {
-        "name": "Stanislav Gumeniuk",
-        "email": "i@vigo.su"
-    }, {
-        "name": "Ali Mihandoost",
-        "email": "i@ali.md"
-    }],
-    "license": "MIT",
-    "dependencies": {
-        "extend": "2.0.1",
-        "request-promise": "1.0.2",
-        "promise": "7.1.1"
+    {
+      "name": "Stanislav Gumeniuk",
+      "email": "i@vigo.su"
+    },
+    {
+      "name": "Ali Mihandoost",
+      "email": "i@ali.md"
     }
+  ],
+  "license": "MIT",
+  "dependencies": {
+    "bluebird": "^3.4.0",
+    "extend": "2.0.1",
+    "promise": "7.1.1",
+    "request-promise": "1.0.2"
+  }
 }


### PR DESCRIPTION
This will throw errors that are unhandled inside `.then()`, right now they are silently swallowed which is really nasty.

Also my editor has removed some whitespace, sorry about that but should be no big deal.
The only actual change is:
```js
var Promise = require('bluebird');

Promise.onPossiblyUnhandledRejection(function(error) {
  throw error;
})
```