### PR TITLE
Customize error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,27 @@ api.on('update', function(message)
 });
 
 ```
+### Error messages
+
+Also you can catch and handle errors
+
+```
+api.on('polling_error', function(error)
+{
+	// Handle error
+});
+
+api.on('parse_error', function(error)
+{
+	// Handle error
+});
+
+api.on('webhook_error', function(error)
+{
+	// Handle error
+});
+
+```
 
 ## Example (send photo)
 
@@ -176,6 +197,7 @@ You should pass configuration object to API constructor, which have following fi
 | updates.enabled | Optional | `true` – API will listen for messages and provide you with callback. `false` – API will not listen for messages, care about it by yourself. Default `false` |
 | updates.get_interval | Optional | This number of milliseconds API will poll Telegram servers for messages. Default `1000` |
 | updates.pooling_timeout | Optional | This number of milliseconds API will keep connection with Telegram servers alive. Default `0` |
+| logger | Optional | Logger. Default `console` |
 
 Example of configuration object
 

--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -32,6 +32,7 @@ Promise.onPossiblyUnhandledRejection(function(error) {
  *      webhook
  *          enabled                 True if you want to receive updates via webhook
  *                                  (one one of updates.enabled or webhook.enabled could be true)
+ *      logger                      logger for bot (default console)
  */
 
 var TelegramApi = function (params)
@@ -81,7 +82,8 @@ var TelegramApi = function (params)
             allowed_updates: [],
             host: '0.0.0.0',
             port: 8443
-        }
+        },
+        logger: console
     };
 
     // Extend default settings with passed params
@@ -90,7 +92,7 @@ var TelegramApi = function (params)
     // Warn use in case if he miss some important params
     if (!_settings.token)
     {
-        console.error('[TelegramBot]: you should pass access token in params');
+        _settings.logger.error('[TelegramBot]: you should pass access token in params');
     }
 
     // Validate params
@@ -187,8 +189,8 @@ var TelegramApi = function (params)
         })
         .catch(function(err)
         {
-            console.error('[TelegramBot]: Failed to get updates from Telegram servers');
-            console.error(err)
+            _settings.logger.error('[TelegramBot]: Failed to get updates from Telegram servers');
+            self.emit('polling_error', err);
 
             setTimeout(internalGetUpdates, _settings.updates.get_interval);
         });
@@ -1787,8 +1789,8 @@ var TelegramApi = function (params)
                     }
             }
             catch(err) {
-                console.log(err)
-                console.log('[TelegramApi]: failed to parse update object')
+                _settings.logger.error('[TelegramApi]: failed to parse update object')
+                self.emit('parse_error', err)
             }
 
             res.status(200)
@@ -1806,7 +1808,7 @@ var TelegramApi = function (params)
             // Started listening
             // setWebhook
             var url = _settings.webhook.url ? _settings.webhook.url + ':' +_settings.webhook.port : 'https://' + _settings.webhook.host + ':' + _settings.webhook.port
-            console.log(url)
+            _settings.logger.info(url)
 
             this.setWebhook({
                 url: url + '/' + _settings.token,
@@ -1815,11 +1817,12 @@ var TelegramApi = function (params)
                 allowed_updates: _settings.webhook.allowed_updates
             })
             .then((d) => {
-                console.log('DONE')
-                console.log(d)
+                _settings.logger.info('DONE')
+                _settings.logger.info(d)
             })
             .catch((err) => {
-                console.log(err)
+              _settings.logger.error('[TelegramApi]: failed to set webhook')
+              self.emit('webhook_error', err)
                 //throw err
             })
 


### PR DESCRIPTION
- added `logger` option. Developers can specify your own logger (like [pino](https://github.com/pinojs/pino), [bunyan](https://github.com/trentm/node-bunyan), [log4js-node](https://github.com/log4js-node/log4js-node), etc). Default - [console](https://developer.mozilla.org/ru/docs/Web/API/Console)
- added events `polling_error`, `parse_error`, `webhook_error`
- updated README