### PR TITLE
Add SendPoll Method

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ getMe
 sendMessage
 forwardMessage
 sendPhoto
+SendPoll
 sendAudio
 sendVoice
 sendDocument

--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -270,6 +270,50 @@ var TelegramApi = function (params)
             });
         }).nodeify(cb);
     };
+    
+    /**
+     *      @sendPoll Use this method to send a native poll. 
+     *      @param chat_id                     [Required] Unique identifier for the message recepient — User or GroupChat id
+     *      @param question                    [Required] Poll question, 1-255 characters
+     *      @param options                     [Required] A array list of answer options, 2-10 strings 1-100 characters each
+     *      @param is_anonymous                True, if the poll needs to be anonymous, defaults to True
+     *      @param type                        Poll type, “quiz” or “regular”, defaults to “regular”
+     *      @param allows_multiple_answers     True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
+     *      @param correct_option_id           0-based identifier of the correct answer option, required for polls in quiz mode
+     *      @param explanation                 Text that is shown when a user chooses an incorrect answer or taps on the lamp icon in a quiz-style poll, 0-200 characters with at most 2 line feeds after entities parsing
+     *      @param open_period                 Amount of time in seconds the poll will be active after creation, 5-600. Can't be used together with close_date.
+     *      @param close_date                  Point in time (Unix timestamp) when the poll will be automatically closed. Must be at least 5 and no more than 600 seconds in the future. Can't be used together with open_period
+     *      @param is_closed                   Pass True, if the poll needs to be immediately closed. This can be useful for poll preview
+     *      @param disable_notification        Sends the message silently. Users will receive a notification with no sound.
+     *      @param reply_to_message_id         If the message is a reply, ID of the original message
+     *      @param reply_markup                Additional interface options. A JSON-serialized object for a custom reply keyboard, instructions to hide keyboard or to force a reply from the user.
+     */
+    this.sendPoll = function (params, cb)
+    {
+       params.options = JSON.stringify(params.options);
+
+        return new Promise(function(resolve, reject)
+        {
+            _rest({
+                method: 'POST',
+                json: true,
+                formData: params,
+                uri: _baseurl + 'sendPoll'
+            })
+            .then(function(body)
+            {
+                return commonResponseHandler(body);
+            })
+            .then(function(data)
+            {
+                resolve(data);
+            })
+            .catch(function(err)
+            {
+                reject(err);
+            });
+        }).nodeify(cb);
+    };
 
     /**
      * METHOD: forwardMessage

--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -5,9 +5,7 @@ var extend = require('extend');
 var request = require('request-promise');
 var EventEmitter = require('events').EventEmitter;
 var Promise = require('bluebird');
-var express = require('express')
-var https = require('https');
-var webapp = express()
+var http = require('http');
 
 Promise.onPossiblyUnhandledRejection(function(error) {
   throw error;
@@ -270,12 +268,12 @@ var TelegramApi = function (params)
             });
         }).nodeify(cb);
     };
-    
+
     /**
      *      @sendPoll Use this method to send a native poll. 
      *      @param chat_id                     [Required] Unique identifier for the message recepient — User or GroupChat id
      *      @param question                    [Required] Poll question, 1-255 characters
-     *      @param options                     [Required] A array list of answer options, 2-10 strings 1-100 characters each
+     *      @param options                     [Required] A JSON-serialized list of answer options, 2-10 strings 1-100 characters each
      *      @param is_anonymous                True, if the poll needs to be anonymous, defaults to True
      *      @param type                        Poll type, “quiz” or “regular”, defaults to “regular”
      *      @param allows_multiple_answers     True, if the poll allows multiple answers, ignored for polls in quiz mode, defaults to False
@@ -489,11 +487,6 @@ var TelegramApi = function (params)
                     args.title = params.title;
                 }
 
-                if (params.caption !== undefined)
-                {
-                    args.caption = params.caption;
-                }
-
                 _rest({
                     method: 'POST',
                     json: true,
@@ -632,11 +625,6 @@ var TelegramApi = function (params)
                 if (params.reply_markup !== undefined)
                 {
                     args.reply_markup = params.reply_markup;
-                }
-
-                if (params.caption !== undefined)
-                {
-                    args.caption = params.caption;
                 }
 
                 _rest({
@@ -1803,10 +1791,31 @@ var TelegramApi = function (params)
 
     // Start webhook
     if (_settings.webhook.enabled == true) {
-        webapp.use(require('body-parser').json())
-        webapp.post('/' + _settings.token, (req, res) => {
-            var data = req.body
-
+        this.setWebhook({
+            url: _settings.webhook.url + '/' + _settings.token,
+            max_connections: _settings.webhook.max_connections,
+            allowed_updates: _settings.webhook.allowed_updates
+        })
+        .then((d) => {
+            console.log('DONE')
+            console.log(d)
+        })
+        .catch((err) => {
+            console.log(err)
+            //throw err
+        })
+     
+server = http.createServer((req, res) => {
+    var body;
+    req.on('data', chunk => {
+        body = chunk.toString();
+      });
+      req.on('end', () => {
+        event_(JSON.parse(body))
+        res.writeHead(200);
+        res.end();
+      });
+function event_(data){
             try {
 
                 //('forEach' in data) && data.forEach(function (item)
@@ -1845,39 +1854,9 @@ var TelegramApi = function (params)
                 console.log('[TelegramApi]: failed to parse update object')
             }
 
-            res.status(200)
-            res.send()
-        })
+        }
+        }).listen(_settings.webhook.port);
 
-        var privateKey = fs.readFileSync(_settings.webhook.privateKey, 'utf8');
-        var certificate = fs.readFileSync(_settings.webhook.certificate, 'utf8');
-        var httpsServer = https.createServer({
-            key: privateKey,
-            cert: certificate
-        }, webapp)
-
-        httpsServer.listen(_settings.webhook.port,  _settings.webhook.host, () => {
-            // Started listening
-            // setWebhook
-            var url = _settings.webhook.url ? _settings.webhook.url + ':' +_settings.webhook.port : 'https://' + _settings.webhook.host + ':' + _settings.webhook.port
-            console.log(url)
-
-            this.setWebhook({
-                url: url + '/' + _settings.token,
-                certificate: _settings.webhook.certificate,
-                max_connections: _settings.webhook.max_connections,
-                allowed_updates: _settings.webhook.allowed_updates
-            })
-            .then((d) => {
-                console.log('DONE')
-                console.log(d)
-            })
-            .catch((err) => {
-                console.log(err)
-                //throw err
-            })
-
-        })
     }
 };
 


### PR DESCRIPTION
Add SendPoll Method to the library
https://core.telegram.org/bots/api#sendpoll

following the update:
April 24, 2020
Bot API 4.8

- Supported explanations for Quizzes 2.0. Add explanations by specifying the parameters explanation and explanation_parse_mode in the method sendPoll.

- Added the fields explanation and explanation_entities to the Poll object.

- Supported timed polls that automatically close at a certain date and time. Set up by specifying the parameter open_period or close_date in the method sendPoll.

- Added the fields open_period and close_date to the Poll object.

