### PR TITLE
fix issue #64

### DIFF
--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -388,6 +388,7 @@ var TelegramApi = function (params)
 
                 var args = {
                     chat_id: params.chat_id,
+                    parse_mode: params.parse_mode,
                     photo: photo
                 };
 

--- a/lib/telegram-bot.js
+++ b/lib/telegram-bot.js
@@ -388,9 +388,11 @@ var TelegramApi = function (params)
 
                 var args = {
                     chat_id: params.chat_id,
-                    parse_mode: params.parse_mode,
                     photo: photo
                 };
+                if (params.parse_mode !== undefined){
+                    args.parse_mode = params.parse_mode;
+                }
 
                 if (params.caption !== undefined)
                 {


### PR DESCRIPTION
add parse_mode to sendPhoto.

test code:
```javascript
api.sendPhoto({
    chat_id,
    caption: "<b>HTML</b>",
    parse_mode: "HTML",
    photo: './img.jpg',
  })
```

before //
after
![oooo](https://user-images.githubusercontent.com/54213349/85342510-2f17d400-b4c1-11ea-8b13-649ee98f0da4.PNG)
